### PR TITLE
Constructor `interpartition_merges` & fixes/small improvements

### DIFF
--- a/docs/src/dtable.md
+++ b/docs/src/dtable.md
@@ -10,7 +10,7 @@ Provide a `Tables.jl` compatible source, as well as a `chunksize`, which is the
 maximum number of rows of each partition:
 
 ```julia
-julia> using Dagger
+julia> using DTables
 
 julia> table = (a=[1, 2, 3, 4, 5], b=[6, 7, 8, 9, 10]);
 
@@ -28,7 +28,7 @@ Provide a `loader_function` and a list of filenames, which are parts of the
 full table:
 
 ```julia
-julia> using Dagger, CSV
+julia> using DTables, CSV
 
 julia> files = ["1.csv", "2.csv", "3.csv"];
 
@@ -99,7 +99,7 @@ Below is an example of their usage.
 For more information please refer to the API documentation and unit tests.
 
 ```julia
-julia> using Dagger
+julia> using DTables
 
 julia> d = DTable((k = repeat(['a', 'b'], 500), v = repeat(1:10, 100)), 100)
 DTable with 10 partitions
@@ -153,16 +153,16 @@ It lets you transform a row to the required format before applying the reduce fu
 In consequence a lot of memory usage should be saved due to the lack of an intermediate `map` step that allocates a full column.
 
 ```julia
-julia> using Dagger, OnlineStats
+julia> using DTables, OnlineStats
 
-julia> fetch(Dagger.mapreduce(sum, fit!, d1, init = Mean()))
+julia> fetch(DTables.mapreduce(sum, fit!, d1, init = Mean()))
 Mean: n=100 | value=1.50573
 
 julia> d1 = DTable((a=collect(1:100).%3, b=rand(100)), 25);
 
 julia> gg = GroupBy(Int, Mean());
 
-julia> fetch(Dagger.mapreduce(x-> (x.a, x.b), fit!, d1, init=gg))
+julia> fetch(DTables.mapreduce(x-> (x.a, x.b), fit!, d1, init=gg))
 GroupBy: Int64 => Mean
 ├─ 1
 │  └─ Mean: n=34 | value=0.491379
@@ -175,7 +175,7 @@ julia> d2 = DTable((;a1=abs.(rand(Int, 100).%2), [Symbol("a\$(i)") => rand(100) 
 
 julia> gb = GroupBy(Int, Group([Series(Mean(), Variance(), Extrema()) for _ in 1:3]...));
 
-julia> fetch(Dagger.mapreduce(r -> (r.a1, tuple(r...)), fit!, d2, init = gb))
+julia> fetch(DTables.mapreduce(r -> (r.a1, tuple(r...)), fit!, d2, init = gb))
 GroupBy: Int64 => Group
 ├─ 1
 │  └─ Group
@@ -208,7 +208,7 @@ GroupBy: Int64 => Group
 ```
 
 
-# Dagger.groupby interface
+# DTables.groupby interface
 
 A `DTable` can be grouped which will result in creation of a `GDTable`.
 A distinct set of values contained in a single or multiple columns can be used as grouping keys.
@@ -224,22 +224,22 @@ julia> d = DTable((a=shuffle(repeat('a':'d', inner=4, outer=4)),b=repeat(1:4, 16
 DTable with 16 partitions
 Tabletype: NamedTuple
 
-julia> Dagger.groupby(d, :a)
+julia> DTables.groupby(d, :a)
 GDTable with 4 partitions and 4 keys
 Tabletype: NamedTuple
 Grouped by: [:a]
 
-julia> Dagger.groupby(d, [:a, :b])
+julia> DTables.groupby(d, [:a, :b])
 GDTable with 16 partitions and 16 keys
 Tabletype: NamedTuple
 Grouped by: [:a, :b]
 
-julia> Dagger.groupby(d, row -> row.a + row.b)
+julia> DTables.groupby(d, row -> row.a + row.b)
 GDTable with 7 partitions and 7 keys
 Tabletype: NamedTuple
 Grouped by: #5
 
-julia> g = Dagger.groupby(d, :a); keys(g)
+julia> g = DTables.groupby(d, :a); keys(g)
 KeySet for a Dict{Char, Vector{UInt64}} with 4 entries. Keys:
   'c'
   'd'
@@ -256,7 +256,7 @@ Tabletype: NamedTuple
 Operations such as `map`, `filter`, `reduce` can be performed on a `GDTable`
 
 ```julia
-julia> g = Dagger.groupby(d, [:a, :b])
+julia> g = DTables.groupby(d, [:a, :b])
 GDTable with 16 partitions and 16 keys
 Tabletype: NamedTuple
 Grouped by: [:a, :b]
@@ -308,7 +308,7 @@ julia> d = DTable((a=repeat('a':'b', inner=2),b=1:4), 2)
 DTable with 2 partitions
 Tabletype: NamedTuple
 
-julia> g = Dagger.groupby(d, :a)
+julia> g = DTables.groupby(d, :a)
 GDTable with 2 partitions and 2 keys
 Tabletype: NamedTuple
 Grouped by: [:a]
@@ -355,7 +355,7 @@ the join functions coming from the `DataFrames.jl` package for the per chunk joi
 In the future this behavior will be expanded to any type that implements its own join methods, but for now is limited to `DataFrame` only.
 
 Please note that the usage of any of the keyword arguments described above will always result in the usage of generic join methods
-defined in `Dagger` regardless of the availability of specialized methods.
+defined in `DTables` regardless of the availability of specialized methods.
 
 ```julia
 julia> using Tables; pp = d -> for x in Tables.rows(d) println("$(x.a), $(x.b), $(x.c)") end;

--- a/src/table/dataframes_interface_utils.jl
+++ b/src/table/dataframes_interface_utils.jl
@@ -101,4 +101,4 @@ function fillcolumns(
 end
 
 ncol(d::DTable) = length(Tables.columns(d))
-index(df::DTable) = Index(_columnnames_svector(df))
+index(df::DTable) = Index(columnnames_svector(df))

--- a/src/table/dtable.jl
+++ b/src/table/dtable.jl
@@ -64,9 +64,10 @@ function DTable(table, chunksize::Integer; tabletype=nothing)
     chunks = Vector{Dagger.Chunk}()
     type = nothing
     sink = Tables.materializer(tabletype !== nothing ? tabletype() : table)
-    for outer_partition in Tables.partitions(table)
+    for outer_partition in Tables.partitions(sink(table))
         for inner_partition in
             Tables.partitions(TableOperations.makepartitions(outer_partition, chunksize))
+
             tpart = sink(inner_partition)
             push!(chunks, Dagger.tochunk(tpart))
             if type === nothing

--- a/src/table/dtable.jl
+++ b/src/table/dtable.jl
@@ -149,7 +149,6 @@ function DTable(loader_function::Function, files::Vector{String}; tabletype=noth
     return DTable(chunks, tabletype)
 end
 
-
 function _file_load(filename::AbstractString, loader_function::Function, tabletype::Any)
     part = loader_function(filename)
     sink = Tables.materializer(tabletype === nothing ? part : tabletype())

--- a/src/table/dtable.jl
+++ b/src/table/dtable.jl
@@ -87,6 +87,13 @@ function DTable(table, chunksize::Integer; tabletype=nothing, interpartition_mer
             if length(inner_partitions) == 1
                 leftovers = merged_data
                 leftovers_length = Tables.length(Tables.rows(leftovers))
+                if leftovers_length == chunksize
+                    # sometimes the next partition will be exactly the size of
+                    # the chunksize - leftovers_length, so perfect match
+                    push!(chunks, Dagger.tochunk(merged_data))
+                    leftovers = nothing
+                    leftovers_length = 0
+                end
                 continue
             else
                 push!(chunks, Dagger.tochunk(merged_data))

--- a/src/table/dtable.jl
+++ b/src/table/dtable.jl
@@ -64,9 +64,9 @@ function DTable(table, chunksize::Integer; tabletype=nothing)
     chunks = Vector{Dagger.Chunk}()
     type = nothing
     sink = Tables.materializer(tabletype !== nothing ? tabletype() : table)
-    for outer_partition in Tables.partitions(sink(table))
+    for outer_partition in Tables.partitions(table)
         for inner_partition in
-            Tables.partitions(TableOperations.makepartitions(outer_partition, chunksize))
+            Tables.partitions(TableOperations.makepartitions(sink(outer_partition), chunksize))
 
             tpart = sink(inner_partition)
             push!(chunks, Dagger.tochunk(tpart))

--- a/src/table/dtable.jl
+++ b/src/table/dtable.jl
@@ -57,6 +57,13 @@ It assumes no initial partitioning of the table and uses the `chunksize`
 argument to partition the table (based on row count).
 
 Providing `tabletype` kwarg overrides the internal table partition type.
+
+Using the `interpartition_merges` kwarg you can decide whether you want to opt out of
+merging rows between partitions. This option is enabled by default, which means it will
+prioritize creating chunks of the specified size even if it means taking rows from two or
+more partitions. When disabled there won't be any merges between partitions meaning several
+chunks can be smaller than expected due to shortage of rows within a partition.
+Please see tests for examples of behaviour.
 """
 function DTable(table, chunksize::Integer; tabletype=nothing, interpartition_merges=true)
     chunks = Dagger.Chunk[]

--- a/src/table/dtable.jl
+++ b/src/table/dtable.jl
@@ -1,8 +1,8 @@
-import Tables
-import TableOperations
+import Base:
+    collect, eltype, fetch, getproperty, isready, iterate, length, names, propertynames, show, wait
 import SentinelArrays
-
-import Base: fetch, show, length, iterate, names, propertynames, wait, isready
+import TableOperations
+import Tables
 
 export DTable, tabletype, tabletype!, trim, trim!, leftjoin, innerjoin, DTableColumn
 
@@ -286,4 +286,12 @@ end
 
 function Base.isready(dt::DTable)
     return all([ch isa Dagger.Chunk ? true : (isready(ch); true) for ch in dt.chunks])
+end
+
+function Base.getproperty(dt::DTable, s::Symbol)
+    if s in fieldnames(DTable)
+        return getfield(dt, s)
+    else
+        return DTableColumn(dt, s)
+    end
 end

--- a/src/table/dtable_column.jl
+++ b/src/table/dtable_column.jl
@@ -75,3 +75,6 @@ function iterate(dtc::DTableColumn, iter)
     pull_next_chunk!(dtc)
     return dtc._iter
 end
+
+Base.eltype(dtc::DTableColumn) = Tables.schema(Tables.columns(dtc.dtable)).types[dtc.col]
+Base.collect(dtc::DTableColumn) = _getcolumn(dtc.dtable, dtc.col)

--- a/src/table/dtable_column.jl
+++ b/src/table/dtable_column.jl
@@ -27,12 +27,12 @@ function DTableColumn(d::DTable, col::Int)
     end
 
     return DTableColumn{column_eltype,iterator_type}(
-        d, col, _columnnames_svector(d)[col], chunk_lengths(d), 0, nothing, nothing
+        d, col, columnnames_svector(d)[col], chunk_lengths(d), 0, nothing, nothing
     )
 end
 
 function DTableColumn(d::DTable, col::String)
-    return DTableColumn(d, only(indexin([col], string.(_columnnames_svector(d)))))
+    return DTableColumn(d, only(indexin([col], string.(columnnames_svector(d)))))
 end
 DTableColumn(d::DTable, col::Symbol) = DTableColumn(d, string(col))
 

--- a/src/table/gdtable.jl
+++ b/src/table/gdtable.jl
@@ -146,6 +146,6 @@ function getindex(gdt::GDTable, key)
     return partition(gdt, ck)
 end
 
-_columnnames_svector(gd::GDTable) = _columnnames_svector(gd.dtable)
+columnnames_svector(gd::GDTable) = columnnames_svector(gd.dtable)
 
 @inline nchunks(gd::GDTable) = length(gd.dtable.chunks)

--- a/src/table/operations.jl
+++ b/src/table/operations.jl
@@ -283,9 +283,9 @@ and `op` is the reduce function applied to the results of the mapping operation.
 
 # Examples
 
-julia> using Dagger, OnlineStats
+julia> using DTables, OnlineStats
 
-julia> fetch(Dagger.mapreduce(sum, fit!, d1, init = Mean()))
+julia> fetch(DTables.mapreduce(sum, fit!, d1, init = Mean()))
 Mean: n=100 | value=1.50573
 """
 

--- a/src/table/operations.jl
+++ b/src/table/operations.jl
@@ -27,9 +27,9 @@ julia> fetch(m)
 """
 function map(f, d::DTable)
     chunk_wrap = (_chunk, _f) -> begin
-        if isnonempty(_chunk)
-            m = TableOperations.map(_f, _chunk)
-            Tables.materializer(_chunk)(m)
+        return if isnonempty(_chunk)
+            sink = Tables.materializer(_chunk)
+            sink(TableOperations.map(_f, _chunk))
         else
             _chunk
         end

--- a/src/table/operations.jl
+++ b/src/table/operations.jl
@@ -100,7 +100,7 @@ function reduce(
     # handle empty dtables
     nchunks(d) == 0 && return Dagger.@spawn NamedTuple()
 
-    columns = cols === nothing ? _columnnames_svector(d) : cols
+    columns = cols === nothing ? columnnames_svector(d) : cols
 
     chunk_reduce_results = _reduce_chunks(f, d.chunks, columns; init=init)
 
@@ -180,7 +180,7 @@ function reduce(
     # handle empty dtables
     nchunks(gd) == 0 && return Dagger.@spawn NamedTuple()
 
-    columns = cols === nothing ? _columnnames_svector(gd) : cols
+    columns = cols === nothing ? columnnames_svector(gd) : cols
 
     chunk_reduce_results = _reduce_chunks(f, gd.dtable.chunks, columns; init=init)
 

--- a/src/table/tables.jl
+++ b/src/table/tables.jl
@@ -65,7 +65,7 @@ function _iterate(iter::DTableRowIterator, chunk_index)
     i = nothing
     row_iterator = nothing
     while i === nothing && chunk_index <= nchunks(iter.d)
-        partition = _retrieve(iter.d.chunks[chunk_index])
+        partition = retrieve(iter.d.chunks[chunk_index])
         row_iterator = Tables.rows(partition)
         i = iterate(row_iterator)
         chunk_index += 1
@@ -121,7 +121,7 @@ length(table::DTablePartitionIterator) = nchunks(table.d)
 
 function _iterate(table::DTablePartitionIterator, chunk_index)
     nchunks(table.d) < chunk_index && return nothing
-    return (_retrieve(table.d.chunks[chunk_index]), chunk_index + 1)
+    return (retrieve(table.d.chunks[chunk_index]), chunk_index + 1)
 end
 
 Base.iterate(table::DTablePartitionIterator) = _iterate(table, 1)

--- a/src/table/tables.jl
+++ b/src/table/tables.jl
@@ -33,7 +33,7 @@ function determine_schema(table::DTable)
     end
     c_idx = 1
     r = (false, nothing)
-    while !r[1] && c_idx <= length(table.chunks)
+    while !r[1] && table.chunks !== nothing && c_idx <= length(table.chunks)
         r = fetch(Dagger.spawn(chunk_f, table.chunks[c_idx]))
         c_idx += 1
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,5 +14,6 @@ using Distributed
 @testset "DTables.jl" begin
     include("table.jl")
     include("table_dataframes.jl")
+    include("tablesjl.jl")
     include("column.jl")
 end

--- a/test/table.jl
+++ b/test/table.jl
@@ -356,7 +356,7 @@ using OnlineStats
 
         for kwargs in kwargs_set
             g = DTables.groupby(d, :a; kwargs...)
-            c = DTables._retrieve.(g.dtable.chunks)
+            c = DTables.retrieve.(g.dtable.chunks)
             @test all([all(t.a[1] .== t.a) for t in c])
             @test all(getindex.(getproperty.(c, :a), 1) .∈ Ref(charset))
             @test sort(collect(fetch(d).a)) == sort(collect(fetch(g).a))
@@ -368,7 +368,7 @@ using OnlineStats
 
         for kwargs in kwargs_set
             g = DTables.groupby(d, [:a, :b]; kwargs...)
-            c = DTables._retrieve.(g.dtable.chunks)
+            c = DTables.retrieve.(g.dtable.chunks)
             @test all([all(t.a[1] .== t.a) for t in c])
             @test all([all(t.b[1] .== t.b) for t in c])
             @test all(getindex.(getproperty.(c, :a), 1) .∈ Ref(charset))
@@ -389,7 +389,7 @@ using OnlineStats
         f2 = x -> x % 10
         for kwargs in kwargs_set
             g = DTables.groupby(d, f1)
-            c = DTables._retrieve.(g.dtable.chunks)
+            c = DTables.retrieve.(g.dtable.chunks)
             @test all([all(f2(t.a[1]) .== f2.(t.a)) for t in c])
             @test all(getindex.(getproperty.(c, :a), 1) .∈ Ref(intset))
             @test sort(collect(fetch(d).a)) == sort(collect(fetch(g).a))
@@ -407,7 +407,7 @@ using OnlineStats
         for key in keys(g.index)
             chunk_indices = g.index[key]
             chunks = getindex.(Ref(g.dtable.chunks), chunk_indices)
-            parts = DTables._retrieve.(chunks)
+            parts = DTables.retrieve.(chunks)
 
             @test all([all(key .== p.a) for p in parts])
         end
@@ -427,7 +427,7 @@ using OnlineStats
         for key in keys(m.index)
             chunk_indices = m.index[key]
             chunks = getindex.(Ref(m.dtable.chunks), chunk_indices)
-            parts = DTables._retrieve.(chunks)
+            parts = DTables.retrieve.(chunks)
             @test all([all((key + 3) .== p.result) for p in parts])
             @test all(fetch(m[key]).a .== key)
         end

--- a/test/table.jl
+++ b/test/table.jl
@@ -548,5 +548,12 @@ using OnlineStats
         @test propertynames(d) == [:a, :b]
         @test wait(d) === nothing
         @test isready(d)
+
+
+        m = map(x-> (ab=x.a + x.b,), d)
+        @test wait(m) === nothing
+        @test isready(m)
+        @test names(m) == ["ab"]
+        @test propertynames(m) == [:ab]
     end
 end

--- a/test/tablesjl.jl
+++ b/test/tablesjl.jl
@@ -1,0 +1,71 @@
+@testset "Tables.jl interface" begin
+    @testset "tables.jl source" begin
+        nt = (a=1:100, b=1:100)
+
+        d1 = DTable(nt, 10) # standard row based constructor
+
+        # partition constructor, check with DTable as input
+        d2 = DTable(d1)
+        d3 = DTable(Tables.partitioner(identity, [nt for _ in 1:10]))
+
+        @test length(d1.chunks) == length(d2.chunks) == length(d3.chunks)
+
+        @test Tables.getcolumn(d1, 1) == 1:100
+        @test Tables.getcolumn(d1, 2) == 1:100
+        @test Tables.getcolumn(d1, :a) == 1:100
+        @test Tables.getcolumn(d1, :b) == 1:100
+        @test DTables.determine_columnnames(d1) == (:a, :b)
+
+        @test DTables.determine_schema(d1).names == (:a, :b)
+        @test DTables.determine_schema(d1).types == (Int, Int)
+
+        for c in Tables.columns(d1)
+            @test c == 1:100
+        end
+
+        @test all([ r.a == r.b == v for (r,v) in zip(collect(Tables.rows(d1)),1:100)])
+
+        # length tests for collect on iterators
+        @test length(d1) == 100
+        @test length(Tables.rows(d1)) == 100
+        @test length(Tables.columns(d1)) == 2
+        @test length(Tables.partitions(d1)) == 10
+
+        # GDTable things
+
+        g = DTables.groupby(d1, r -> r.a % 10, chunksize=3)
+        t1 = Tables.columntable(Tables.rows(g))
+        @test 1:100 == sort(t1.a) == sort(t1.b)
+        t2 = collect(Tables.columns(g))
+        @test 1:100 == sort(t2[1]) == sort(t2[2])
+
+        for partition in Tables.partitions(g)
+            @test partition isa DTable
+            v = Tables.getcolumn(partition, :a)[1]
+            @test all([el%10 == v%10 for el in Tables.getcolumn(partition, :a)])
+        end
+    end
+
+    @testset "remaining utilities" begin
+        nt = (; a=[1,2,3], b=[2,2,3])
+
+        d = DTable(nt, 1)
+
+        @test Tables.istable(d)
+        @test Tables.rowaccess(d)
+        @test Tables.columnaccess(d)
+
+        @test Tables.getcolumn(Tables.columns(d), :a) == [1, 2, 3]
+
+        gd = DTables.groupby(d, :b)
+
+        @test Tables.istable(gd)
+        @test Tables.rowaccess(gd)
+        @test Tables.columnaccess(gd)
+        @test Tables.schema(gd).names == (:a, :b)
+        @test Tables.schema(gd).types == (Int64, Int64)
+        @test Tables.getcolumn(gd, :a) == [1, 2, 3]
+        @test Tables.getcolumn(gd, 1) == [1, 2, 3]
+        @test Tables.columnnames(gd) == (:a, :b)
+    end
+end


### PR DESCRIPTION
WIP: trying out some things on constructors to make them faster/more reliable

## Findings/features

1. materialization before ingesting the input avoids the huge allocation numbers that scale with input length 

```julia
# pre change
julia> @time DTable(CSV.File("test.csv"), 12000)

  0.141167 seconds (4.92 M allocations: 123.415 MiB)
DTable with 84 partitions
Tabletype: NamedTuple

# post change

julia> @time DTable(CSV.File("test.csv"), 12000)

  0.021110 seconds (8.09 k allocations: 48.421 MiB)
DTable with 84 partitions
Tabletype: NamedTuple
```

2. interpartition merges 

```julia
julia> DTable(CSV.Chunks("test.csv"), 70_000) |> DTables.chunk_lengths
15-element Vector{Int64}:
 70000
 70000
 70000
 70000
 70000
 70000
 70000
 70000
 70000
 70000
 70000
 70000
 70000
 70000
 20000

julia> DTable(CSV.Chunks("test.csv"), 70_000, interpartition_merges=false) |> DTables.chunk_lengths
16-element Vector{Int64}:
 62495
 62502
 62505
 62493
 62505
 62501
 62492
 62507
 62495
 62502
 62505
 62493
 62505
 62501
 62492
 62507

julia> DTable(CSV.Chunks("test.csv"), 50_000) |> DTables.chunk_lengths
20-element Vector{Int64}:
 50000
 50000
 50000
 50000
 50000
 50000
 50000
 50000
 50000
 50000
 50000
 50000
 50000
 50000
 50000
 50000
 50000
 50000
 50000
 50000

julia> DTable(CSV.Chunks("test.csv"), 50_000, interpartition_merges=false) |> DTables.chunk_lengths
32-element Vector{Int64}:
 50000
 12495
 50000
 12502
 50000
 12505
 50000
 12493
 50000
 12505
 50000
 12501
     ⋮
 12505
 50000
 12493
 50000
 12505
 50000
 12501
 50000
 12492
 50000
 12507
```

3. getting columns throgh properties works now and returns a lazy DTableColumn iterator 
it can be used for efficiently iterating through the column and it has a specialized `collect` function defined that uses the `Tables.getcolumn` implementation that efficiently links all column pieces into a SentinelArray 

```julia
julia> d.a |> collect
100000-element SentinelArrays.ChainedVector{Int64, Vector{Int64}}:
 1
 2
 0
 1
 2
 0
 1
 ⋮
 1
 2
 0
 1
 2
 0
 1

julia> d.a |> sum
100000
```

3. docs updates