### PR TITLE
Add `transform` and `combine` from DataFrames

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 InvertedIndices = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
 SentinelArrays = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TableOperations = "ab02a1b2-a7df-11e8-156e-fb1833f50b87"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 

--- a/src/DTables.jl
+++ b/src/DTables.jl
@@ -16,6 +16,7 @@ using DataFrames:
     make_pair_concrete
 using InvertedIndices: Not
 using SentinelArrays: ChainedVector
+using Statistics: mean
 using TableOperations: TableOperations
 using Tables:
     columnindex,

--- a/src/DTables.jl
+++ b/src/DTables.jl
@@ -54,7 +54,7 @@ import Base:
 import DataAPI: leftjoin, ncol, nrow, innerjoin
 import Tables:
     columnaccess, columnnames, columns, getcolumn, istable, partitions, rowaccess, rows, schema
-import DataFrames: broadcast_pair, select, index
+import DataFrames: broadcast_pair, combine, select, index, transform
 
 ############################################################################################
 # Export
@@ -64,6 +64,7 @@ export All,
     AsTable,
     Between,
     ByRow,
+    combine,
     Cols,
     DTable,
     DTableColumn,
@@ -75,6 +76,7 @@ export All,
     select,
     tabletype,
     tabletype!,
+    transform,
     trim,
     trim!
 ############################################################################################

--- a/src/DTables.jl
+++ b/src/DTables.jl
@@ -55,7 +55,7 @@ import Base:
 import DataAPI: leftjoin, ncol, nrow, innerjoin
 import Tables:
     columnaccess, columnnames, columns, getcolumn, istable, partitions, rowaccess, rows, schema
-import DataFrames: broadcast_pair, combine, select, index, transform
+import DataFrames: broadcast_pair, combine, groupby, select, index, transform
 
 ############################################################################################
 # Export
@@ -75,6 +75,7 @@ export All,
     Not,
     nrow,
     select,
+    groupby,
     tabletype,
     tabletype!,
     transform,

--- a/src/operations/dataframes_interface.jl
+++ b/src/operations/dataframes_interface.jl
@@ -120,7 +120,7 @@ function _manipulate(df::DTable, normalized_cs::Vector{Any}, copycols::Bool, kee
         z = zeros(Int, nchunks(df))
         z[1] = 1
         z
-    else # TODO: this is a bad temp solution
+    else
         b = maximum(fullcolumn_ops_result_lengths)
         a = zeros(Int, nchunks(df))
         avg_chunk_length = floor(Int, mean(chunk_lengths(df)))

--- a/src/operations/dataframes_interface.jl
+++ b/src/operations/dataframes_interface.jl
@@ -147,3 +147,25 @@ function select(
         renamecols=renamecols,
     )
 end
+
+function transform(
+    df::DTable,
+    @nospecialize(args...);
+    copycols::Bool=true,
+    renamecols::Bool=true,
+    threads::Bool=true,
+)
+    return select(df, :, args...; copycols=copycols, renamecols=renamecols, threads=threads)
+end
+
+function combine(
+    df::DTable, @nospecialize(args...); renamecols::Bool=true, threads::Bool=true
+)
+    return manipulate(
+        df,
+        map(x -> broadcast_pair(df, x), args)...;
+        copycols=true,
+        keeprows=false,
+        renamecols=renamecols,
+    )
+end

--- a/src/operations/dataframes_interface_utils.jl
+++ b/src/operations/dataframes_interface_utils.jl
@@ -33,8 +33,8 @@ end
 
 function fillcolumn(
     chunk,
-    csymbols::Union{Vector{DataType},Vector{Symbol}, Vector{Union{DataType,Symbol}}},
-    colfragments::Union{Vector{Dagger.EagerThunk}, Vector{Any}},
+    csymbols::Union{Vector{DataType},Vector{Symbol},Vector{Union{DataType,Symbol}}},
+    colfragments::Union{Vector{Dagger.EagerThunk},Vector{Any}},
     expected_chunk_length::Int,
     normalized_cs::Vector{Any},
 )
@@ -82,17 +82,30 @@ function fillcolumn(
 end
 
 function fillcolumns(
-    dt::DTable,
+    dt::Union{Nothing,DTable},
     normalized_cs_results::Dict{Int,Dagger.EagerThunk},
     normalized_cs::Vector{Any},
     new_chunk_lengths::Vector{Int},
     fullcolumn_ops_result_lengths::Vector{Int},
 )
     fullcolumn_ops_indices_in_normalized_cs = collect(keys(normalized_cs_results))::Vector{Int}
-    fullcolumn_ops_results_ordered = map(x -> normalized_cs_results[x], fullcolumn_ops_indices_in_normalized_cs)::Union{Vector{Any},Vector{Dagger.EagerThunk}}
+    fullcolumn_ops_results_ordered = map(
+        x -> normalized_cs_results[x], fullcolumn_ops_indices_in_normalized_cs
+    )::Union{Vector{Any},Vector{Dagger.EagerThunk}}
 
     colfragment = (column, s, e) -> Dagger.@spawn getindex(column, s:e)
-    result_column_symbols = getindex.(Ref(map(x -> x[2][2], normalized_cs)), fullcolumn_ops_indices_in_normalized_cs)
+    result_column_symbols =
+        getindex.(Ref(map(x -> x[2][2], normalized_cs)), fullcolumn_ops_indices_in_normalized_cs)
+
+    dtchunks = if dt === nothing
+        [Dagger.spawn(() -> nothing) for _ in 1:length(new_chunk_lengths)]
+    else
+        dt.chunks
+    end
+    dtchunks_filled = [
+        x <= length(dtchunks) ? dtchunks[x] : Dagger.spawn(() -> nothing) for
+        x in 1:length(new_chunk_lengths)
+    ]
 
     chunks = Dagger.EagerThunk[
         Dagger.spawn(
@@ -101,15 +114,23 @@ function fillcolumns(
             result_column_symbols,
             [
                 if len > 1
-                    colfragment(column, 1 + sum(new_chunk_lengths[1:(i - 1)]), sum(new_chunk_lengths[1:i]))
+                    colfragment(
+                        column, 1 + sum(new_chunk_lengths[1:(i - 1)]), sum(new_chunk_lengths[1:i])
+                    )
                 else
                     column
-                end for (column, len) in zip(fullcolumn_ops_results_ordered, fullcolumn_ops_result_lengths)
+                end for
+                (column, len) in zip(fullcolumn_ops_results_ordered, fullcolumn_ops_result_lengths)
             ],
             new_chunk_length,
             normalized_cs,
-        )
-        for (i, (chunk, new_chunk_length)) in enumerate(zip(dt.chunks, new_chunk_lengths)) if new_chunk_length > 0
+        ) for
+        (i, (chunk, new_chunk_length)) in enumerate(zip(dtchunks_filled, new_chunk_lengths)) if
+        new_chunk_length > 0
     ]
-    return DTable(chunks, dt.tabletype)
+    if dt === nothing
+        return DTable(chunks, nothing)
+    else
+        return DTable(chunks, dt.tabletype)
+    end
 end

--- a/test/table_dataframes.jl
+++ b/test/table_dataframes.jl
@@ -80,9 +80,10 @@ using SentinelArrays: ChainedVector
             result
         end
 
-
-        @test t(:a => mean, :b)
         @test t(:a => mean)
+        @test t(:a => mean, :b)
+        @test t(:a => mean, :b => mean)
+        @test t(:a => mean, :b, :b => mean)
         @test t([] => (()-> ones(5_000)), :a => mean)
         @test t([] => (()-> ones(15_000)), :a => mean)
     end

--- a/test/table_dataframes.jl
+++ b/test/table_dataframes.jl
@@ -7,7 +7,7 @@ using SentinelArrays: ChainedVector
 
 @testset "dtable-dataframes" begin
     @testset "select" begin
-        s = 100_000
+        s = 10_000
         nt = (a=collect(1:s) .% 3, b=rand(s))
         dt = DTable(nt, s ÷ 10)
         df = fetch(dt, DataFrame)
@@ -60,5 +60,30 @@ using SentinelArrays: ChainedVector
         @test names(v, Not(:a)) == names(v, r"x") == ["x1", "x2", "x3", "x4"]
         @test names(v, :x1) == names(v, 2) == ["x1"]
         @test names(v, Cols()) == names(v, Cols()) == []
+    end
+
+    @testset "combine" begin
+        s = 10_000
+        nt = (a=collect(1:s) .% 3, b=rand(s))
+        dt = DTable(nt, s ÷ 10)
+        df = fetch(dt, DataFrame)
+
+        t = (args...) -> begin
+            dt_01 = combine(dt, args...)
+            df_01 = combine(df, args...)
+
+            result = try
+                all(isapprox.(Tables.columns(df_01), Tables.columns(fetch(dt_01, DataFrame))))
+            catch
+                all(isequal.(Tables.columns(df_01), Tables.columns(fetch(dt_01, DataFrame))))
+            end
+            result
+        end
+
+
+        @test t(:a => mean, :b)
+        @test t(:a => mean)
+        @test t([] => (()-> ones(6_000)), :a => mean )
+        # combine(dt, [] => (() -> dt[1:3,1]) => :efaw)
     end
 end

--- a/test/table_dataframes.jl
+++ b/test/table_dataframes.jl
@@ -83,6 +83,7 @@ using SentinelArrays: ChainedVector
 
         @test t(:a => mean, :b)
         @test t(:a => mean)
-        @test t([] => (()-> ones(6_000)), :a => mean)
+        @test t([] => (()-> ones(5_000)), :a => mean)
+        @test t([] => (()-> ones(15_000)), :a => mean)
     end
 end

--- a/test/table_dataframes.jl
+++ b/test/table_dataframes.jl
@@ -83,7 +83,6 @@ using SentinelArrays: ChainedVector
 
         @test t(:a => mean, :b)
         @test t(:a => mean)
-        @test t([] => (()-> ones(6_000)), :a => mean )
-        # combine(dt, [] => (() -> dt[1:3,1]) => :efaw)
+        @test t([] => (()-> ones(6_000)), :a => mean)
     end
 end


### PR DESCRIPTION
transform is a simple addintion, but combine needs the handling of `keeprows` implemented in order to function correctly

todo:
- [x] add handling of keeprows to make combine work like combine and not like select
- [x] add tests for combine