### PR TITLE
Groupby reduce with string grouping keys fix

### DIFF
--- a/src/operations/operations.jl
+++ b/src/operations/operations.jl
@@ -196,8 +196,12 @@ function reduce(
     ]
 
     construct_result =
-        (_keys, _gcols, _columns, _results, _prefix) -> begin
-            ks = [col => getindex.(_keys, i) for (i, col) in enumerate(_gcols)]
+        (_keys::Base.KeySet, _gcols, _columns, _results, _prefix) -> begin
+            ks = if eltype(_keys) <: NamedTuple # many keys in groupby
+                [col => getindex.(_keys, col) for col in _gcols]
+            else # single key in groupby
+                [col => collect(_keys) for col in _gcols]
+            end
             rs = [
                 Symbol(_prefix * string(r)) => fetch(_results[i]) for (i, r) in enumerate(_columns)
             ]

--- a/test/table.jl
+++ b/test/table.jl
@@ -435,6 +435,15 @@ using OnlineStats
         r = reduce(*, g)
         fr = fetch(r)
 
+        a = DTable((a=rand(["abc", "bcd", "efg"], 100), b=rand(100)), 11)
+        r = fetch(reduce((x, y) -> x + y, DTables.groupby(a, :a), cols=[:b], init=0))
+        @test all(a.a .∈ Ref(r.a))
+
+        a = DTable((a=rand(["abc", "bcd", "efg"], 100), b=rand(100)), 11)
+        r = fetch(reduce((x, y) -> x + y, DTables.groupby(a, [:a, :b]), cols=[:b], init=0))
+        @test all(a.a .∈ Ref(r.a))
+        @test all(a.b .∈ Ref(r.b))
+
         for (i, key) in enumerate(fr.a)
             @test fr.result_a[i] == repeat(key, length(cs1) ÷ 4)
             @test fr.result_b[i] == 3 ^ (length(cs1) ÷ 4)


### PR DESCRIPTION
```
a = DTable((a=rand(["abc", "bcd", "efg"], 100), b=rand(100)), 11)
r = fetch(reduce((x, y) -> x + y, DTables.groupby(a, :a), cols=[:b], init=0))
```
it would return `r.a = ['a', 'b', 'e']`
