### PR TITLE
Add disk caching interface

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -3,3 +3,4 @@ margin = 100
 always_use_return = true
 whitespace_in_kwargs = false
 import_to_using = false
+ignore = ["test", "misc", "docs"]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
         version:
           - '1.7'
           - '1.8'
+          - '1.9'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.8.2]
+        julia-version: [1.9.2]
         julia-arch: [x86]
         os: [ubuntu-latest]
     steps:
@@ -23,7 +23,7 @@ jobs:
       - name: Install JuliaFormatter and format
         run: |
           julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
-          julia  -e 'using JuliaFormatter; format("src", verbose=true)'
+          julia  -e 'using JuliaFormatter; format(".", verbose=true)'
       - name: Format check
         run: |
           julia -e '

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DTables"
 uuid = "20c56dc6-594c-4682-91cf-1d46875b1eba"
 authors = ["Krystian Guliński", "Julian Samaroo", "and contributors"]
-version = "0.3.2"
+version = "0.4.0"
 
 [deps]
 Dagger = "d58978e5-989f-55fb-8d15-ea34adc7bf54"
@@ -14,9 +14,9 @@ TableOperations = "ab02a1b2-a7df-11e8-156e-fb1833f50b87"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-Dagger = "0.16.1, 0.17"
+Dagger = "0.18"
 DataAPI = "1"
-DataFrames = "1.4"
+DataFrames = "1.4,1.5,1.6"
 InvertedIndices = "1"
 SentinelArrays = "1"
 TableOperations = "1"

--- a/src/DTables.jl
+++ b/src/DTables.jl
@@ -69,6 +69,7 @@ export All,
     Cols,
     DTable,
     DTableColumn,
+    enable_disk_caching!,
     innerjoin,
     leftjoin,
     ncol,
@@ -83,6 +84,7 @@ export All,
     trim!
 ############################################################################################
 
+include("utilities.jl")
 include("table/dtable.jl")
 include("table/gdtable.jl")
 include("table/tables.jl")

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,0 +1,3 @@
+function enable_disk_caching!(ram_percentage_limit=30, disk_limit_gb=32^2*10)
+    return Dagger.enable_disk_caching!(ram_percentage_limit, disk_limit_gb)
+end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,3 +1,3 @@
-function enable_disk_caching!(ram_percentage_limit=30, disk_limit_gb=32^2*10)
+function enable_disk_caching!(ram_percentage_limit=30, disk_limit_gb=32^2 * 10)
     return Dagger.enable_disk_caching!(ram_percentage_limit, disk_limit_gb)
 end


### PR DESCRIPTION
```julia
# PS C:\Users\krynjupc\.julia\dev\DTables> julia -t4 -p4 


julia> using DTables

[ Info: Precompiling DTables [20c56dc6-594c-4682-91cf-1d46875b1eba]

julia> enable_disk_caching!()
[ Info: Disk cache setup successful
true

julia> DTables.Dagger.inspect_global_devices()
5-element Vector{Pair{Int64, MemPool.SimpleRecencyAllocator}}:
 1 => SimpleRecencyAllocator(mem: 0 bytes used (1.916 GiB max), device: 0 bytes used (10.000 GiB max), policy: MRU)
 2 => SimpleRecencyAllocator(mem: 0 bytes used (1.916 GiB max), device: 0 bytes used (10.000 GiB max), policy: MRU)
  Stats: 0 Hits, 0 Misses, 0 Evicts
 3 => SimpleRecencyAllocator(mem: 0 bytes used (1.916 GiB max), device: 0 bytes used (10.000 GiB max), policy: MRU)
  Stats: 0 Hits, 0 Misses, 0 Evicts
 4 => SimpleRecencyAllocator(mem: 0 bytes used (1.916 GiB max), device: 0 bytes used (10.000 GiB max), policy: MRU)
  Stats: 0 Hits, 0 Misses, 0 Evicts
 5 => SimpleRecencyAllocator(mem: 0 bytes used (1.916 GiB max), device: 0 bytes used (10.000 GiB max), policy: MRU)
  Stats: 0 Hits, 0 Misses, 0 Evicts
```