### PR TITLE
Adding `first`, `last` and `describe` convenience functions.

### DIFF
--- a/src/DTables.jl
+++ b/src/DTables.jl
@@ -28,6 +28,7 @@ using Tables:
     materializer,
     partitioner,
     rows,
+    rowtable,
     schema,
     Schema
 

--- a/src/table/dtable.jl
+++ b/src/table/dtable.jl
@@ -4,6 +4,7 @@ const VTYPE = Vector{Union{Dagger.Chunk,Dagger.EagerThunk}}
     DTable
 
 Structure representing the distributed table based on Dagger.
+
 The table is stored as a vector of `Chunk` structures which hold partitions of the table.
 That vector can also store `Dagger.EagerThunk` structures when an operation that modifies
 the underlying partitions was applied to it (currently only `filter`).
@@ -16,6 +17,7 @@ end
 
 DTable(chunks::Vector, tabletype) = DTable(VTYPE(chunks), tabletype, nothing)
 DTable(chunks::Vector, tabletype, schema) = DTable(VTYPE(chunks), tabletype, schema)
+
 """
     DTable(table; tabletype=nothing) -> DTable
 


### PR DESCRIPTION
Still a draft PR.

This PR adds implementations of the `first`, `last` and `describe` convenience functions.

## Examples

```julia
julia> using DTables;

julia> table = (a=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10], b=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);

julia> d = DTable(table, 3)
DTable with 4 partitions
Tabletype: NamedTuple

julia> first_five = DTables.first(d, UInt(5))
DTable with 2 partitions
Tabletype: NamedTuple

julia> fetch(first_five)
(a = [1, 2, 3, 4, 5], b = [1, 2, 3, 4, 5])

```

TODO:

- [ ] Finalize implementation of `first`.
- [ ] Finalize implementation of `last`.
- [ ] Finalize implementation of `describe`.
- [ ] Add documentation.
- [ ] Add relevant tests.