### PR TITLE
removing type annotations from loader_function per #32

### DIFF
--- a/src/table/dtable.jl
+++ b/src/table/dtable.jl
@@ -153,8 +153,6 @@ function _file_load(filename::AbstractString, loader_function, tabletype::Any)
     return tpart
 end
 
-
-
 """
     fetch(d::DTable)
 

--- a/src/table/dtable.jl
+++ b/src/table/dtable.jl
@@ -130,6 +130,8 @@ function DTable(table, chunksize::Integer; tabletype=nothing, interpartition_mer
     return DTable(chunks, type)
 end
 
+
+
 """
     DTable(loader_function, files::Vector{String}; tabletype=nothing)
 
@@ -139,19 +141,21 @@ one file is used to create one partition.
 
 Providing `tabletype` kwarg overrides the internal table partition type.
 """
-function DTable(loader_function::Function, files::Vector{String}; tabletype=nothing)
+function DTable(loader_function, files::Vector{String}; tabletype=nothing)
     chunks = Dagger.EagerThunk[
         Dagger.spawn(_file_load, file, loader_function, tabletype) for file in files
     ]
     return DTable(chunks, tabletype)
 end
 
-function _file_load(filename::AbstractString, loader_function::Function, tabletype::Any)
+function _file_load(filename::AbstractString, loader_function, tabletype::Any)
     part = loader_function(filename)
     sink = materializer(tabletype === nothing ? part : tabletype())
     tpart = sink(part)
     return tpart
 end
+
+
 
 """
     fetch(d::DTable)

--- a/src/table/dtable.jl
+++ b/src/table/dtable.jl
@@ -130,8 +130,6 @@ function DTable(table, chunksize::Integer; tabletype=nothing, interpartition_mer
     return DTable(chunks, type)
 end
 
-
-
 """
     DTable(loader_function, files::Vector{String}; tabletype=nothing)
 

--- a/test/table.jl
+++ b/test/table.jl
@@ -91,6 +91,20 @@ using OnlineStats
         @test da.tabletype === NamedTuple
     end
 
+    @testset "file loaders - CSV.File compatibility" begin
+        # for this interface: https://juliaparallel.org/DTables.jl/dev/dtable/#Underlying-table-type
+        size = 10
+        nt = (a = rand(Int, size), b = rand(Int, size))
+        fname = tempname()
+        CSV.write(fname, nt)
+
+        files = [fname, fname, fname]
+        dt = DTable(CSV.File, files)
+
+        @test all(fetch(dt).a .== vcat(nt.a, nt.a, nt.a))
+        @test all(fetch(dt).b .== vcat(nt.b, nt.b, nt.b))
+    end
+
     @testset "constructors - interpartition merges" begin
         size = 1_000
         nt = (a = rand(size), b = rand(size))


### PR DESCRIPTION
Enabling generation of a DTable via `d = DTable(CSV.File, files)` by removing the `::Function` type annotation per the suggestion in [this thread](https://github.com/JuliaLang/julia/issues/43491). 