### PR TITLE
fix(join): declare loop-spawned closure locals to avoid soft-scope race

### DIFF
--- a/src/operations/join_interface.jl
+++ b/src/operations/join_interface.jl
@@ -158,6 +158,11 @@ function _join(
 
     process_one_chunk =
         (type, l, r, cmp_l, cmp_r, other_r, lookup, r_sorted, l_sorted, r_unique) -> begin
+            # Variables below MUST be `local`: identifiers `inner_l`, `inner_r`, `outer_l`
+            # are also assigned in the enclosing `_join` body, so Julia's soft-scope rules
+            # would otherwise capture them by reference. Multiple `Dagger.@spawn`ed
+            # invocations of this closure would then race on the same binding cells.
+            local inner_l, inner_r, outer_l
             inner_l, inner_r = match_inner_indices(
                 l, r, cmp_l, cmp_r, lookup, r_sorted, l_sorted, r_unique
             )

--- a/test/table.jl
+++ b/test/table.jl
@@ -532,7 +532,7 @@ using OnlineStats
             @test isequal(lj1u, lj7)
             @test isequal(lj1, lj8)
             @test isequal(lj1, lj9)
-            # @test isequal(lj1, lj10)
+            @test isequal(lj1, lj10)
 
             ij1 = innerjoin(d1, d2, on=on)
             ij1u = innerjoin(d1, unique(d2, r_colsymbols), on=on)
@@ -557,7 +557,7 @@ using OnlineStats
             @test isequal(ij1u, ij7)
             @test isequal(ij1, ij8)
             @test isequal(ij1, ij9)
-            # @test isequal(ij1, ij10)
+            @test isequal(ij1, ij10)
             @test isequal(ij1, ij11)
         end
     end


### PR DESCRIPTION
## Summary

`_join(::Symbol, ::Any, ::DTable)`'s `process_one_chunk` closure assigns to `inner_l`, `inner_r`, and `outer_l` — names that are *also* assigned later in the enclosing `_join` body (the `intersect` / `Vector{UInt}()` initialization for the outer-row merge). Julia's soft-scope rules therefore make those identifiers **captured bindings** shared between the enclosing function and every `Dagger.@spawn`ed invocation of the closure.

With N r-chunks the closure runs N times in parallel, all reading/writing the same three binding cells. The tuple destructure

```julia
inner_l, inner_r = match_inner_indices(...)
```

is two stores; a context switch between them lets one task observe another task's `inner_l` paired with its own `inner_r`. Mismatched lengths trigger a `BoundsError` in `build_joined_table`, and even when lengths happen to match, `find_outer_indices(l, inner_l)` runs against the wrong `inner_l` and the final merge ends up with extra rows. The bug manifested as `DTable`-on-`DTable` `leftjoin`/`innerjoin` returning the wrong row count under `-t>1`.

The fix is one line inside the closure:

```julia
local inner_l, inner_r, outer_l
```

That forces fresh per-invocation bindings and resolves the race. No other `Dagger.@spawn` site in `src/` has the same trap — they all use `_`-prefixed parameter names, have inner locals that don't collide with the enclosing function, or are only spawned once.

This also re-enables the previously commented-out `lj10` / `ij10` assertions in `test/table.jl` that exercise `DTable`-on-`DTable` joins.

## Test plan

- [x] Full test suite passes: `368/368` under `julia -t8`
- [x] `lj10` / `ij10` `DTable`-on-`DTable` join asserts re-enabled and pass
- [x] 50 fresh-cache `leftjoin` + `innerjoin` trials on `-t8` — `0/50` mismatches (vs reliably wrong on `main`)
- [x] 30 stress trials with cold `determine_schema` cache per iteration — `0/30` mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)